### PR TITLE
fix: SaveGame:Delete(string identifier), identifier cannt be a directory

### DIFF
--- a/Assets/BayatGames/SaveGameFree/Scripts/SaveGame.cs
+++ b/Assets/BayatGames/SaveGameFree/Scripts/SaveGame.cs
@@ -821,9 +821,15 @@ namespace BayatGames.SaveGameFree
             if (IOSupported())
             {
 #if UNITY_WSA || UNITY_WINRT
-				UnityEngine.Windows.File.Delete ( filePath );
+                if (UnityEngine.Windows.File.Exists(filePath))
+                    UnityEngine.Windows.File.Delete(filePath);
+                else if (UnityEngine.Windows.Directory.Exists(filePath))
+                    UnityEngine.Windows.Directory.Delete(filePath, true);
 #else
-                File.Delete(filePath);
+                if (File.Exists(filePath))
+                    File.Delete(filePath);
+                else if (Directory.Exists(filePath))
+                    Directory.Delete(filePath, true);
 #endif
             }
             else


### PR DESCRIPTION
now, we can do like this:
SaveGame.Save("save1/profile", profileData);
SaveGame.Save("save1/item", itemData);
SaveGame.Delete("save1")

btw, SaveGame:DeleteAll(PersistentDataPath) will remove all data in the persistentDataPath, maybe exists data for other use. So, i thought the SaveGame.Delete("save1") is necessary.