### PR TITLE
Closes Issue #12

### DIFF
--- a/Assets/BayatGames/SaveGameFree/Scripts/SaveGame.cs
+++ b/Assets/BayatGames/SaveGameFree/Scripts/SaveGame.cs
@@ -1046,7 +1046,9 @@ namespace BayatGames.SaveGameFree
             Application.platform != RuntimePlatform.WSAPlayerARM &&
             Application.platform != RuntimePlatform.WSAPlayerX64 &&
             Application.platform != RuntimePlatform.WSAPlayerX86 &&
+#if !UNITY_2017_3_OR_NEWER
             Application.platform != RuntimePlatform.SamsungTVPlayer &&
+#endif
             Application.platform != RuntimePlatform.tvOS &&
             Application.platform != RuntimePlatform.PS4;
         }


### PR DESCRIPTION
This added 2 lines of a preprocessor to check for the right version of unity (`#if UNITY_2017_3_OR_NEWER`) and 
 should close Issue #12 (which i just wrote) which is about a warning about Samsung support in Unity 2019.  I selected 2017_3 because that version was specifically called out in the warning.  

<!--
Read the [contributing guidelines](https://github.com/BayatAssetStore/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/BayatAssetStore/.github/blob/main/support.md
https://github.com/BayatAssetStore/.github/blob/main/contributing.md
-->
